### PR TITLE
Add OB ID box to hdriver

### DIFF
--- a/hcam_widgets/hcam.py
+++ b/hcam_widgets/hcam.py
@@ -703,7 +703,7 @@ class InstPars(tk.LabelFrame):
             elif not self.isDrift():
                 self.clear.config(state='normal')
                 self.clearLab.config(state='normal')
-                
+
         # allow posting if parameters are OK. update count and SN estimates too
         if status:
             if (g.cpars['hcam_server_on'] and g.cpars['eso_server_online'] and
@@ -1072,7 +1072,6 @@ class RunPars(tk.LabelFrame):
         self.comment = w.TextEntry(self, 38)
         self.comment.grid(row=row, column=column, sticky=tk.W)
 
-
     def loadJSON(self, json_string):
         """
         Sets the values of the run parameters given an JSON string
@@ -1138,12 +1137,13 @@ class RunPars(tk.LabelFrame):
             self.prog_ob.configure(state='disable')
             self.target.disable()
         else:
-            self.pi.configure(state='normal')
             if expert:
+                self.pi.configure(state='normal')
                 self.prog_ob.configure(state='normal')
                 self.prog_ob.enable()
             else:
                 self.prog_ob.configure(state='disable')
+                self.pi.configure(state='disable')
                 self.prog_ob.disable()
             self.target.enable()
 
@@ -1183,13 +1183,15 @@ class RunPars(tk.LabelFrame):
     def setExpertLevel(self):
         g = get_root(self).globals
         expert = g.cpars['expert_level'] > 0
-        if expert:                
+        if expert:
+            self.pi.configure(state='normal')
             self.prog_ob.configure(state='normal')
             self.prog_ob.enable()
         else:
             self.prog_ob.configure(state='disable')
+            self.pi.configure(state='disable')
             self.prog_ob.disable()
-            
+
     def freeze(self):
         """
         Freeze all settings so that they can't be altered

--- a/hcam_widgets/widgets.py
+++ b/hcam_widgets/widgets.py
@@ -1816,6 +1816,38 @@ class Stop(ActButton):
             return False
 
 
+class ProgramID(tk.Frame):
+    """
+    Class to combine the ProgramID and OB number.
+
+    This is a text entry field and a PosInt widget bound together.
+    The point of this widget is simply to get a nice layout.
+    """
+    def __init__(self, master):
+        tk.Frame.__init__(self, master)
+        self.master = master
+        check = master.check if hasattr(master, 'check') else None
+        self.progid = TextEntry(self, 20, check)
+        self.obid = PosInt(self, 1, check, True, width=4)
+    
+        self.progid.pack(side=tk.LEFT, anchor=tk.W)
+        tk.Label(self, text='/').pack(side=tk.LEFT, anchor=tk.W, padx=2)
+        self.obid.pack(side=tk.LEFT, anchor=tk.W, padx=2)
+
+    def disable(self):
+        self.obid.disable()
+
+    def enable(self):
+        self.obid.enable()
+
+    def ok(self):
+        return self.progid.ok() & self.obid.ok()
+
+    def configure(self, **kwargs):
+        self.progid.configure(**kwargs)
+        self.obid.configure(**kwargs)
+
+
 class Target(tk.Frame):
     """
     Class wrapping up what is needed for a target name which


### PR DESCRIPTION
As requested by vik, we add the OB ID number to a widget in the ```RunPars``` area of hdriver. However, to avoid this being accidentally messed with, as it should normally come direct from the JSON file defining the phase II, this is an expert-mode only option.

Likewise, the PI and programme ID are now expert mode only, and should normally be defined by the phase II JSON file.