### PR TITLE
Manage changes in hcam_devices package

### DIFF
--- a/hcam_widgets/hcam.py
+++ b/hcam_widgets/hcam.py
@@ -1653,8 +1653,6 @@ class Start(w.ActButton):
         NGC telemetry topic with this function as the callback. 
         """
         telemetry = pickle.loads(package)
-
-        g = get_root(self).globals
         res = ReadNGCTelemetry(telemetry)
         if not res.ok:
             raise DriverError('cannot read NGC telemetry: ' + str(res.err))

--- a/hcam_widgets/misc.py
+++ b/hcam_widgets/misc.py
@@ -371,7 +371,7 @@ def insertFITSHDU(g):
 @inlineCallbacks
 def execCommand(g, command, timeout=10):
     """
-    Executes a command by sending it to the rack server
+    Executes a command by sending it to the NGC server
 
     Arguments:
       g : hcam_drivers.globals.Container
@@ -384,10 +384,10 @@ def execCommand(g, command, timeout=10):
       start              : starts a run
       stop               : stops a run
       abort              : aborts a run
-      ngc_server.online  : bring ESO control server online and power up hardware
-      ngc_server.offline : put ESO control server in idle state and power down
-      ngc_server.standby : server can communicate, but child processes disabled
-      reset   : resets the NGC controller front end
+      online             : bring ESO control server online and connect it to hardware
+      offline            : put ESO control server in idle state and power down
+      standby            : server can communicate, but child processes disabled
+      reset              : resets the NGC controller front end
 
     Returns True/False according to whether the command
     succeeded or not.

--- a/hcam_widgets/widgets.py
+++ b/hcam_widgets/widgets.py
@@ -2455,7 +2455,7 @@ class InstSetup(tk.LabelFrame):
                 self.cldcOff.disable()
             # power on/off
             if (res.clocks == 'enabled'
-                    and ngc_status.lower == 'online'):
+                    and ngc_status.lower() == 'online'):
                 self.powerOff.enable()
                 self.powerOn.disable()
             else:

--- a/hcam_widgets/widgets.py
+++ b/hcam_widgets/widgets.py
@@ -2048,7 +2048,7 @@ class NGCStandby(ActButton):
         g.clog.debug('NGC Standby pressed')
         session = root.globals.session
         try:
-            yield session.call('hipercam.ngc.rpc.ngc_server.standby')
+            yield session.call('hipercam.ngc.rpc.standby')
         except Exception as err:
             g.clog.warn('NGC Standby failed: ' + str(err))
             returnValue(False)
@@ -2084,7 +2084,7 @@ class NGCOnline(ActButton):
         g.clog.debug('NGC Online pressed')
         session = root.globals.session
         try:
-            yield session.call('hipercam.ngc.rpc.ngc_server.online')
+            yield session.call('hipercam.ngc.rpc.online')
         except Exception as err:
             msg = err.error_message() if hasattr(err, 'error_message') else str(err)
             g.clog.warn("NGC Online failed: " + msg)
@@ -2123,7 +2123,7 @@ class NGCOff(ActButton):
         g.clog.debug('NGC Off pressed')
         session = root.globals.session
         try:
-            yield session.call('hipercam.ngc.rpc.ngc_server.offline')
+            yield session.call('hipercam.ngc.rpc.offline')
         except Exception as err:
             msg = err.error_message() if hasattr(err, 'error_message') else str(err)
             g.clog.warn("NGC Off failed: " + msg)
@@ -2320,19 +2320,7 @@ class PowerOn(ActButton):
         g.clog.debug('Power on pressed')
         try:
             session = root.globals.session
-            yield session.call('hipercam.ngc.rpc.ngc_server.online')
-            # this will queue the transition to online state, but
-            # will return immediately, so unless we wait here,
-            # we will try to power on CLDC before the server is online
-            online = False
-            waited = 0
-            while (not online) or (waited < 1.0):
-                online = yield isOnline(g)
-                yield async_sleep(0.1)
-                waited += 0.1
-            if not online:
-                raise RuntimeError('failed to move to online status')
-
+            yield session.call('hipercam.ngc.rpc.online')
         except Exception as err:
             msg = err.error_message() if hasattr(err, 'error_message') else str(err)
             g.clog.warn('Failed to bring server online: ' + msg)
@@ -2400,7 +2388,7 @@ class PowerOff(ActButton):
             g.clog.warn('Unable to power off CLDC')
             returnValue(False)
 
-        success = yield execCommand(g, 'ngc_server.offline')
+        success = yield execCommand(g, 'offline')
         if success:
             g.clog.info('ESO server idle')
             g.cpars['eso_server_online'] = False
@@ -2455,7 +2443,7 @@ class InstSetup(tk.LabelFrame):
         g = get_root(self).globals
         try:
             telemetry = pickle.loads(package)
-            ngc_status = telemetry['state']['ngc_server']
+            ngc_status = telemetry.get('system.stateName', 'unknown')
             res = ReadNGCTelemetry(telemetry)
             # clocks
             if res.clocks == 'enabled':
@@ -2467,7 +2455,7 @@ class InstSetup(tk.LabelFrame):
                 self.cldcOff.disable()
             # power on/off
             if (res.clocks == 'enabled'
-                    and 'online' in ngc_status):
+                    and ngc_status.lower == 'online'):
                 self.powerOff.enable()
                 self.powerOn.disable()
             else:

--- a/hcam_widgets/widgets.py
+++ b/hcam_widgets/widgets.py
@@ -2320,7 +2320,9 @@ class PowerOn(ActButton):
         g.clog.debug('Power on pressed')
         try:
             session = root.globals.session
-            yield session.call('hipercam.ngc.rpc.online')
+            msg, ok = yield session.call('hipercam.ngc.rpc.online')
+            if not ok:
+                raise RuntimeError(msg)
         except Exception as err:
             msg = err.error_message() if hasattr(err, 'error_message') else str(err)
             g.clog.warn('Failed to bring server online: ' + msg)


### PR DESCRIPTION
In https://github.com/HiPERCAM/hcam_devices/pull/12, we removed the NGC state machine from the hcam_devices package, and added RPCs for turning the NGC server on and off. In this PR, we make the necessary corresponding changes to hcam_widgets